### PR TITLE
added autoupdate workflow

### DIFF
--- a/.github/workflows/update_recipe.yml
+++ b/.github/workflows/update_recipe.yml
@@ -1,0 +1,54 @@
+name: Check homebrew recipe and modify versions if necessary
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    branches:
+      - master
+
+jobs:
+  checkupdate:
+    runs-on: ubuntu-latest
+    env:
+      RECIPE: Formula/datafy.rb
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.REPO_TOKEN }}
+
+    - name: Check latest version
+      id: latest-version
+      run: |
+        echo ::set-output name=latest::$(curl -s https://app.datafy.cloud/api/info/cli/version)
+
+    - name: Check current version
+      id: current-version
+      run: |
+        echo ::set-output name=current::$(grep "version \".*\"" $RECIPE | grep -o "[0-9]*\.[0-9]*.[0-9]*")
+
+    - name: Modify recipe if they are different
+      if: steps.latest-version.latest != steps.current-version.current
+      run: |
+        version=${${{ steps.latest-version.latest }}}
+        old_version=${${{ steps.current-version.current }}}
+        pathmac=datafy_mac.tar.gz
+        pathlinux=datafy_linux.tar.gz
+        curl -sL https://datafy-cp-artifacts.s3-eu-west-1.amazonaws.com/cli/${version}/datafy_darwin_amd64.tar.gz -o $pathmac
+        curl -sL https://datafy-cp-artifacts.s3-eu-west-1.amazonaws.com/cli/${version}/datafy_linux_amd64.tar.gz -o $pathlinux
+        sma=($(sha256sum $pathmac))
+        sma=${sma[0]}
+        sli=($(sha256sum $pathlinux))
+        sli=${sli[0]}
+        shas=($sma $sli)
+        sed -i "s:${old_version}:${version}:g" $RECIPE
+        index=$((0))
+        grep "sha256" $RECIPE | grep -o "\"[0-9a-f]\+\"" | while read -r line; do sed -i "s:${line}:\"${shas[$index]}\":g" $RECIPE && index=$((index+1)) ; done
+        rm $pathmac
+        rm $pathlinux
+
+    - name: Trigger a pull request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        commit-message: Updated from version ${{ steps.current-version.current }} to ${{ steps.latest-version.latest }}

--- a/.github/workflows/update_recipe.yml
+++ b/.github/workflows/update_recipe.yml
@@ -38,22 +38,7 @@ jobs:
     - name: Modify recipe if they are different
       if: steps.same.outputs.version == 'false'
       run: |
-        version=${{ steps.latest.outputs.version }}
-        old_version=${{ steps.current.outputs.version }}
-        pathmac=datafy_mac.tar.gz
-        pathlinux=datafy_linux.tar.gz
-        curl -sL https://datafy-cp-artifacts.s3-eu-west-1.amazonaws.com/cli/${version}/datafy_darwin_amd64.tar.gz -o $pathmac
-        curl -sL https://datafy-cp-artifacts.s3-eu-west-1.amazonaws.com/cli/${version}/datafy_linux_amd64.tar.gz -o $pathlinux
-        sma=($(sha256sum $pathmac))
-        sma=${sma[0]}
-        sli=($(sha256sum $pathlinux))
-        sli=${sli[0]}
-        shas=($sma $sli)
-        sed -i "s:${old_version}:${version}:g" $RECIPE
-        index=$((0))
-        grep "sha256" $RECIPE | grep -o "\"[0-9a-f]\+\"" | while read -r line; do sed -i "s:${line}:\"${shas[$index]}\":g" $RECIPE && index=$((index+1)) ; done
-        rm $pathmac
-        rm $pathlinux
+        python3 release.py --noninteractive
 
     - name: Trigger a pull request
       uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/update_recipe.yml
+++ b/.github/workflows/update_recipe.yml
@@ -4,8 +4,8 @@ on:
   schedule:
     - cron: "0 0 * * *"
   push:
-    branches:
-      - master
+    paths:
+      - '.github/workflows/update_recipe.yml'
 
 jobs:
   checkupdate:
@@ -15,24 +15,31 @@ jobs:
     steps:
     - name: Check out repo
       uses: actions/checkout@v2
-      with:
-        token: ${{ secrets.REPO_TOKEN }}
 
     - name: Check latest version
-      id: latest-version
+      id: latest
       run: |
-        echo ::set-output name=latest::$(curl -s https://app.datafy.cloud/api/info/cli/version)
+        echo "::set-output name=version::$(curl -s https://app.datafy.cloud/api/info/cli/version)"
 
     - name: Check current version
-      id: current-version
+      id: current
       run: |
-        echo ::set-output name=current::$(grep "version \".*\"" $RECIPE | grep -o "[0-9]*\.[0-9]*.[0-9]*")
+        echo "::set-output name=version::$(grep 'version \".*\"' $RECIPE | grep -o '[0-9]*\.[0-9]*.[0-9]*')"
+
+    - name: Check if they are the same
+      id: same
+      run: |
+        current=${{ steps.current.outputs.version }}
+        latest=${{ steps.latest.outputs.version }}
+        echo $latest
+        echo $current
+        echo "::set-output name=version::$(if [ $latest == $current ]; then echo 'true'; else echo 'false'; fi)"
 
     - name: Modify recipe if they are different
-      if: steps.latest-version.latest != steps.current-version.current
+      if: steps.same.outputs.version == 'false'
       run: |
-        version=${${{ steps.latest-version.latest }}}
-        old_version=${${{ steps.current-version.current }}}
+        version=${${{ steps.latest.outputs.version }}}
+        old_version=${${{ steps.current.outputs.version }}}
         pathmac=datafy_mac.tar.gz
         pathlinux=datafy_linux.tar.gz
         curl -sL https://datafy-cp-artifacts.s3-eu-west-1.amazonaws.com/cli/${version}/datafy_darwin_amd64.tar.gz -o $pathmac
@@ -51,4 +58,4 @@ jobs:
     - name: Trigger a pull request
       uses: peter-evans/create-pull-request@v3
       with:
-        commit-message: Updated from version ${{ steps.current-version.current }} to ${{ steps.latest-version.latest }}
+        commit-message: Updated from version ${{ steps.current.outputs.version }} to ${{ steps.latest.outputs.version }}

--- a/.github/workflows/update_recipe.yml
+++ b/.github/workflows/update_recipe.yml
@@ -38,8 +38,8 @@ jobs:
     - name: Modify recipe if they are different
       if: steps.same.outputs.version == 'false'
       run: |
-        version=${${{ steps.latest.outputs.version }}}
-        old_version=${${{ steps.current.outputs.version }}}
+        version=${{ steps.latest.outputs.version }}
+        old_version=${{ steps.current.outputs.version }}
         pathmac=datafy_mac.tar.gz
         pathlinux=datafy_linux.tar.gz
         curl -sL https://datafy-cp-artifacts.s3-eu-west-1.amazonaws.com/cli/${version}/datafy_darwin_amd64.tar.gz -o $pathmac

--- a/.github/workflows/update_recipe.yml
+++ b/.github/workflows/update_recipe.yml
@@ -1,4 +1,4 @@
-name: Check homebrew recipe and modify versions if necessary
+name: Check homebrew recipe and modify versions
 
 on:
   schedule:

--- a/release.py
+++ b/release.py
@@ -29,9 +29,10 @@ print(f"Downloading releases from {release_urls}")
 shas = {platform: hashlib.sha256(ur.urlopen(url).read()).hexdigest() for platform, url in release_urls.items()}
 print(f"Release hashes: {shas}")
 
-if noninteractive or input("upgrade formula definition? y/N   ") != "y":
-  print("Exiting")
-  exit()
+if not noninteractive:
+    if input("upgrade formula definition? y/N   ") != "y":
+        print("Exiting")
+        exit()
 
 blocks = {}
 for key in release_urls:
@@ -64,10 +65,12 @@ formula=f"""class Datafy < Formula
 end
 """
 formula_path.write_text(formula)
+print("Updated forumula")
 
-if (noninteractive and noninteractive_push) or input("commit to repo and push? y/N   ") != "y":
-  print("Exiting")
-  exit()
+if not noninteractive_push:
+    if noninteractive or input("commit to repo and push? y/N   ") != "y":
+        print("Exiting")
+        exit()
 
 print("Committing new version to repo and pushing")
 subprocess.run(f"git add . && git commit -m 'upgrade to v{latest_version}' && git push", shell=True)


### PR DESCRIPTION
This is just an idea and not urgent, don't merge in current state and feel free to discard/modify/ignore for a while. I once had a repo containing a recipe for building a project in another repo. To ensure the recipe automatically updated itself when a new version was released I implemented something similar to this. I thought maybe it could be useful here too. The idea would be that a new release of datafy triggers a pull request with an updated recipe. Of course better is triggering the workflow with some web hook set up in the main repo instead of a schedule. A secret token would be needed such that the workflow can create a branch and pull request.